### PR TITLE
support features updating misc.htm

### DIFF
--- a/misc.rb
+++ b/misc.rb
@@ -1,19 +1,18 @@
 #
-# File    : kawahigashi.rb
+# File    : misc.rb
 # Author  : Kazune Takahashi
-# Created : 1/16/2019, 10:54:10 PM
+# Created : 5/1/2021, 2:52:12 PM
 # Powered by Visual Studio Code
 #
 
-class Kawahigashi
+class Misc
   require './news.rb'
   require 'open-uri'
   require 'nokogiri'
 
-  attr_accessor :year, :components, :texts
+  attr_accessor :components, :texts
 
   def initialize(url)
-    @year = nil
     @components = nil
     @texts = []
     doc = nil
@@ -27,19 +26,12 @@ class Kawahigashi
     if doc.nil?
       return nil
     end
-    x = doc.xpath("/html/body/h1")
-    if x && m = x.text.match(/(\d{4})年/)
-      @year = m[1].to_i
-    end
-    if @year.nil?
-      return nil
-    end
-    x = doc.xpath("/html/body/p")
+    x = doc.xpath("/html/body/ul/li")
     if x
       @components = []
       x.each{|para|
         n = News.new()
-        if n.make_news(para, :news)
+        if n.make_news(para, :misc)
           @components << n
         end
       }
@@ -47,13 +39,14 @@ class Kawahigashi
     if @components.nil? || @components.empty?
       return nil
     end
+    @components.reverse!
     @components.each{|news|
       @texts << news.to_s
     }
   end
 
   def valid?
-    !(@year.nil? || @components.nil? || @components.empty? ||
+    !(@components.nil? || @components.empty? ||
        @texts.nil? || @texts.empty?)
   end
 

--- a/news.rb
+++ b/news.rb
@@ -15,12 +15,14 @@ class News
     @urls = []
   end
 
-  def make_news(para)
+  def make_news(para, type)
     str = para.text
-    if str[0] == "・"
-      str = str[1...-1]
-    else
-      return nil
+    if type == :news
+      if str[0] == "・"
+        str = str[1...-1]
+      else
+        return nil
+      end
     end
     str = str.gsub(/[\r\n]/, "").strip
     date_reg_exp = /\((\d{1,2})\/(\d{1,2})\/(\d{4})\)$/
@@ -31,6 +33,9 @@ class News
     end
     str = str.gsub(date_reg_exp, "").strip
     @text = str
+    if type == :misc
+      @text = "『" + @text + "』"
+    end
     # p @text
     @urls = []
     para.css('a').each{|link|
@@ -56,7 +61,7 @@ class News
     ans.gsub!(/@/, "%40")
     ans.gsub!(/\.$/, "%2E")
     if !uri.scheme
-      ans = "http://www.ms.u-tokyo.ac.jp/~yasuyuki/" + ans
+      ans = "https://www.ms.u-tokyo.ac.jp/~yasuyuki/" + ans
     end
     return ans
   end


### PR DESCRIPTION
## 目的

先日、河東先生のページに[どうでもよい記事](https://www.ms.u-tokyo.ac.jp/~yasuyuki/misc.htm)ができました。一発ネタではなく、現在まで、記事が追加されつづけているようです。そこで、記事が追加されるたびに河東セミナーニュース bot にも投稿するように、プログラムを追記いたしました。

ご査収くだされば幸いです。

## 主な追加機能

ニュースのページと同時に、どうでもよい記事のページを巡回し、新しい記述があれば投稿します。方法や仕様は今までのニュースと同様です。ニュース生成部分のソースを可能な限り再利用するようにしました。

## その他の変更点

相対リンクを絶対リンクに直す際に `http://` ではじめていましたが、 `https://` ではじめるようにしました。これに伴いましてローカルで生成される `texts.txt` の文字列が変更になります。そのため、何も対策なしに動かしますと、多くの記述が再投稿されてしまいます。テストや本番稼働でこの点を円滑にするために `refresh()`, `update_texts()`, `write_texts()` を用意しました。 irb や pry で `bot.rb` を `load` し、 `Bot` インスタンスを initialize した後これらを実行すれば `texts.txt` の文字列が最新状態になります。

年が変更になった際に `@year` を更新していないというバグが見つかったので、修正しました。