### PR TITLE
replace '*' by '＊' on text due to twitter-gem problem

### DIFF
--- a/news.rb
+++ b/news.rb
@@ -36,6 +36,7 @@ class News
     if type == :misc
       @text = "『" + @text + "』"
     end
+    @text.gsub!(/\*/, "＊")
     # p @text
     @urls = []
     para.css('a').each{|link|
@@ -60,6 +61,7 @@ class News
     ans.gsub!(/'/, "%27")
     ans.gsub!(/@/, "%40")
     ans.gsub!(/\.$/, "%2E")
+    ans.gsub!(/\*$/, "%2A")
     if !uri.scheme
       ans = "https://www.ms.u-tokyo.ac.jp/~yasuyuki/" + ans
     end


### PR DESCRIPTION
## 要約

投稿本文の `*` は `＊` に置き換えます。

## 本文

### 問題点

以下のものがうまくいきませんでした。

```ruby
bot.client.update("05/05: 8月にドイツで開かれるYoung Mathematicians in C*-Algebrasの形態は，オンラインまたはハイブリッドということです． https://ymcstara.org/current-1.html")
```

結果は以下のとおりです。

```
Twitter::Error::Unauthorized: Could not authenticate you.
```

`*` が含まれている投稿は、このエラーが出ます。

### 原因

これは `twitter` gem の問題です。調査内容は https://github.com/sferik/twitter/issues/677#issuecomment-586547719 にまとまっています。これを見て実験する限り、 gem の使い手が `*` を `%2A` にエスケープするのは意味がありません。なお、すでに修正が https://github.com/sferik/twitter/pull/969 で提案されています。

### 影響範囲

このおかげで、上記ニュース以降のニュースがすべて投稿されていません。

$C^*$-環は、河東先生のご専門 (von Neumann 環) とは違う(一種だというのはともかく)ものの、作用素環論の研究対象であるため、今後もニュースや記事タイトルに登場すると見込まれます。 2019 年以降のニュースに一度も `*` が登場していなかったので、今まで発覚しませんでした。対策が必須です。

### 解決策

致し方ないので、投稿本文の `*` を全角の `＊` に置き換えます。これでうまくいくのはテスト済みです。美しくはないですが、すべて日本語で書かれているので、こういう事情ならば許容されるかと存じます。

## 備考

この問題は #1 の変更とは全く関係がありません。

この修正を反映させて `clockwork` を再度実行すれば、該当ニュース以降が反映されると見込まれます。

どうぞ、よろしくお願いします。